### PR TITLE
:sparkles:Feat : 일기 수정페이지에서 뒤로 갈 경우의 로직 추가

### DIFF
--- a/app/(main)/mydiary/write-diary/page.tsx
+++ b/app/(main)/mydiary/write-diary/page.tsx
@@ -183,11 +183,7 @@ export default function WriteDiaryPage() {
   }, [selectedTags])
 
   const handleEmotionClick = () => {
-    if (step === 1) {
-      setStep(2)
-    } else {
-      setStep(1)
-    }
+    setStep(2)
   }
 
   const handleTagClick = (id: string) => {
@@ -271,7 +267,6 @@ export default function WriteDiaryPage() {
   const handleSave = () => {
     const requestBody = {
       type: "mydiary",
-      // product_id: parseInt(userId),
       extra: {
         title: noteTitleVal,
         content: noteContentVal,
@@ -291,6 +286,7 @@ export default function WriteDiaryPage() {
     }
   }
 
+  console.log("isEditMode@@@@@@@@@@@@@@@@@@@@@@@@", isEditMode)
   return (
     <>
       {step === 1 && !isEditMode && (
@@ -313,7 +309,7 @@ export default function WriteDiaryPage() {
       )}
       {step === 2 && (
         <>
-          <NavigationHeader isMood={true} isSave={true} />
+          <NavigationHeader isEditMode={true} isMood={true} isSave={true} />
           <div className="text-primary px-6">
             {isEditMode && (
               <div className="flex justify-between gap-2 my-6">

--- a/components/navigation-header.tsx
+++ b/components/navigation-header.tsx
@@ -14,6 +14,7 @@ interface NavigationHeaderProps {
   isSave?: boolean
   isDate?: boolean
   isSearch?: boolean
+  isEditMode?: boolean
 }
 
 const handleBtnClick = () => {}
@@ -23,13 +24,23 @@ export const NavigationHeader = ({
   isSave,
   isDate,
   isSearch,
+  isEditMode,
 }: NavigationHeaderProps) => {
+  const { seter } = useDiaryValues()
   const { moodVal } = useDiaryValues()
-  const { back } = useRouter()
+  const { back, push } = useRouter()
+  const handleBack = () => {
+    if (isEditMode) {
+      seter(false, "isEditMode")
+      push("/mydiary")
+    } else {
+      back()
+    }
+  }
   return (
     <div className="w-full flex justify-between items-center py-[12px] ">
       <div className="flex">
-        <Button variant="ghost" onClick={back}>
+        <Button variant="ghost" onClick={handleBack}>
           <ChevronLeft className="text-primary" width={32} height={32} />
         </Button>
         {isMood && (


### PR DESCRIPTION
## PR 유형
어떤 변경 사항이 있나요?
일기 수정 페이지에서 수정 완료버튼을 누르지않고 navigation-header의 뒤로가기 버튼을 눌렀을 떄
전역변수인 isEditMode 값을 초기화 해주는 로직 추가

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] aseets 파일 추가

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://github.com/FRONTENDSCHOOLPLUS2/PODA/wiki/%EC%BB%A4%EB%B0%8B-%EC%BB%A8%EB%B2%A4%EC%85%98) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
