### PR TITLE
🐛 바텀시트 버그 해결

### DIFF
--- a/app/(main)/mydiary/[diaryId]/write-note/page.tsx
+++ b/app/(main)/mydiary/[diaryId]/write-note/page.tsx
@@ -33,7 +33,7 @@ export default function WriteNotePage() {
       <div className="p-6 pt-16">
         <Input
           placeholder="제목 입력..."
-          className="mb-2 outline-none border-none placeholder:text-3xl placeholder:text-primary placeholder:font-extrabold text-primary text-3xl font-extrabold"
+          className="mb-2 outline-none border-none placeholder:text-3xl placeholder:text-[#c4c4c4] placeholder:font-extrabold text-primary text-3xl font-extrabold"
           value={noteTitleVal}
           onChange={(e) => {
             handleTitleVal(e)

--- a/app/(main)/mydiary/new/write-note/page.tsx
+++ b/app/(main)/mydiary/new/write-note/page.tsx
@@ -32,7 +32,7 @@ export default function WriteNotePage() {
       <div className="h-full px-6 pt-16">
         <Input
           placeholder="제목 입력..."
-          className="mb-2 outline-none border-none placeholder:text-3xl placeholder:text-primary placeholder:font-extrabold text-primary text-3xl font-extrabold"
+          className="mb-2 outline-none border-none placeholder:text-3xl placeholder:text-[#c4c4c4] placeholder:font-extrabold text-primary text-3xl font-extrabold"
           value={noteTitleVal}
           onChange={(e) => {
             handleTitleVal(e)

--- a/components/interest-bottom-sheet.tsx
+++ b/components/interest-bottom-sheet.tsx
@@ -18,7 +18,7 @@ import { useInterestSheet } from "@/hooks/store/use-interest-sheet"
 import { useSelectedDiary } from "@/hooks/store/use-selected-diary"
 import { useCurrentSession } from "@/hooks/use-current-session"
 
-import { usePathname, useRouter } from "next/navigation"
+import { usePathname } from "next/navigation"
 import React, { useEffect } from "react"
 import { toast } from "sonner"
 
@@ -58,29 +58,28 @@ export const interests: string[] = [
 ]
 
 export const InterestBottomSheet = () => {
-  const { isOpen, onOpen, onClose, setOpen } = useInterestSheet()
+  const { isOpen, onClose, setOpen } = useInterestSheet()
   const { selectDiary, myInterest, setMyInterest, onReset, interest } =
     useSelectedDiary()
-  const { push } = useRouter()
   const pathname = usePathname()
   const { mutate } = useAddProduct()
 
   const { data } = useCurrentSession()
 
-  const { userInterest } = useUserInfo(data?.user?._id as string)
+  const { userInterest, userExtra } = useUserInfo(data?.user?._id as string)
   const { mutate: patchUserMutate } = usePatchUser(Number(data?.user?._id))
-  console.log("interest: ", interest)
 
-  // 바텀시트가 열고 닫으면 기존값으로 초기화 해주기
+  // 수정없이 바텀시트를 닫으면, 초기화해주기
   useEffect(() => {
     if (pathname === "/mypage") {
       setMyInterest(userInterest)
     }
-  }, [userInterest, pathname])
+  }, [isOpen])
 
   const handleEdit = () => {
     const requestBody = {
       extra: {
+        ...userExtra,
         interest: myInterest,
       },
     }
@@ -115,18 +114,15 @@ export const InterestBottomSheet = () => {
         interest: [...interest],
       },
     }
-
     if (!selectDiary) {
       return
     }
-
     try {
       mutate(requestBody)
     } catch (error) {
       console.log(error)
     } finally {
       onClose()
-      //   onReset()
     }
   }
 

--- a/components/navigation-header.tsx
+++ b/components/navigation-header.tsx
@@ -2,12 +2,12 @@
 
 import React from "react"
 import { Button } from "./ui/button"
-import { ChevronLeft, Search } from "lucide-react"
+import { ChevronLeft, FileEdit, Search } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { useRouter } from "next/navigation"
+import { useParams, useRouter } from "next/navigation"
 import Image from "next/image"
 import { useDiaryValues } from "@/hooks/store/use-diary"
-import { useAddPost } from "@/hooks/mutation/post"
+import { useAddPost, usePatchPost } from "@/hooks/mutation/post"
 
 interface NavigationHeaderProps {
   isBack?: boolean
@@ -42,8 +42,9 @@ export const NavigationHeader = ({
     selectedTags,
     resetValues,
   } = useDiaryValues()
-
-  const { mutate } = useAddPost()
+  const { diaryId } = useParams()
+  const { mutate: addPostMutate } = useAddPost()
+  const { mutate: patchPostMutate } = usePatchPost(Number(diaryId))
   const { back, push } = useRouter()
 
   const handleSave = () => {
@@ -58,12 +59,32 @@ export const NavigationHeader = ({
     }
 
     try {
-      mutate(requestBody)
+      addPostMutate(requestBody)
     } catch (error) {
       console.log(error)
     } finally {
       push("/mydiary")
       resetValues()
+    }
+  }
+
+  const handleEdit = () => {
+    const requestBody = {
+      extra: {
+        title: noteTitleVal,
+        content: noteContentVal,
+        mood: moodVal,
+        tag: selectedTags ? [...selectedTags] : [],
+      },
+    }
+    try {
+      const res = patchPostMutate(requestBody)
+      console.log("res: ", res)
+    } catch (error) {
+      console.log(error)
+    } finally {
+      resetValues()
+      push("/mydiary")
     }
   }
 
@@ -130,13 +151,28 @@ export const NavigationHeader = ({
         className={cn("text-primary flex gap-2", !isSave && "hidden")}
         onClick={handleSave}>
         <Image
-          width={28}
-          height={28}
+          width={30}
+          height={30}
           src={"/assets/svg/checkBtn.svg"}
           alt="저장버튼"
           className={cn(!isSave && "hidden")}
         />
         저장
+      </Button>
+
+      <Button
+        variant="ghost"
+        disabled={!isEditMode}
+        className={cn("text-primary flex gap-2", !isEditMode && "hidden")}
+        onClick={handleEdit}>
+        <div className="bg-mainColor rounded-full p-[6px]">
+          <FileEdit
+            width={20}
+            height={20}
+            className={cn("text-black -mr-[1px]", !isEditMode && "hidden")}
+          />
+        </div>
+        수정
       </Button>
     </div>
   )

--- a/hooks/query/user.tsx
+++ b/hooks/query/user.tsx
@@ -13,9 +13,11 @@ export const useUserInfo = (id: string) => {
     staleTime: 1000 * 3,
   })
   const userInterest = data?.item?.extra?.interest
+  const userExtra = data?.item?.extra
   return {
     data,
     userInterest,
+    userExtra,
     isPending,
     error,
     refetch,


### PR DESCRIPTION
## PR 유형
어떤 변경 사항이 있나요?

- mypage에서 바텀시트를 열고, 관심사를 여러가지 선택한 뒤 수정을 누르지 않고 바텀 시트를 닫았을 경우, myInterest 값을 기존 유저의 관심사 값으로 초기화해주는 코드 추가
- navigation-header의 수정 버튼 기능 구현 및 아이콘 수정
- write-note 페이지 Title placeholder 색상값 #c4c4c4 로 수정

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] aseets 파일 추가

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://github.com/FRONTENDSCHOOLPLUS2/PODA/wiki/%EC%BB%A4%EB%B0%8B-%EC%BB%A8%EB%B2%A4%EC%85%98) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
